### PR TITLE
fixed length in match timestamps

### DIFF
--- a/cyber/dataset/utils.py
+++ b/cyber/dataset/utils.py
@@ -38,10 +38,10 @@ def match_timestamps(times_a, times_b):
             j += 1
     # fill in the rest
     if i < len(times_a):
-        matches_a[i:] = [j - 1] * (len(times_b) - i)
+        matches_a[i:] = [j - 1] * (len(times_a) - i)
         diffs_a[i:] = [abs(times_a[i] - times_b[-1])] * (len(times_a) - i)
     if j < len(times_b):
-        matches_b[j:] = [i - 1] * (len(times_a) - j)
+        matches_b[j:] = [i - 1] * (len(times_b) - j)
         diffs_b[j:] = [abs(times_a[-1] - times_b[j])] * (len(times_b) - j)
     return matches_a, matches_b, diffs_a, diffs_b
 

--- a/cyber/models/world/autoencoder/cosmos_tokenizer/modules/quantizers.py
+++ b/cyber/models/world/autoencoder/cosmos_tokenizer/modules/quantizers.py
@@ -1,4 +1,5 @@
 # ruff: noqa: E402
+# ruff: noqa: RUF052
 # SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #


### PR DESCRIPTION
## 🎯 What does this PR do?
<!-- Concise description of the changes -->

Previously the function's return would have the wrong lengths. Now they match the expected.

## 🔍 Related Issues
<!-- Link to any related issues using #issue_number -->

## ✅ Quality Checklist
- [x] Ran `pre-commit` checks locally
  - [x] Passed Ruff linting and formatting
  - [x] Passed MyPy type checking
- [ ] Added/updated tests
  - [ ] Updated documentation
- [x] Verified changes locally
- [x] No new warnings generated

## 🧪 Test Instructions
<!-- Steps to test the changes -->

Create two different sized ascending integer arrays and pass them to the function. The lengths should match.

## 📝 Additional Notes
<!-- Any additional information that reviewers should know -->

## 💻 Local Verification Steps
```bash
# Run these commands to verify your changes
pre-commit run --all-files
pytest tests/  # if you modified any tested code
```
